### PR TITLE
Add SCS to compatibility exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The main effect of this component is that you'll get less expensive loot, and co
 
 ## Compatibility
 - Install Unique Artifacts _after_ any mods that add, change or move content (areas, creatures, quests, items, etc). Basically, as late as possible.
-- Item Randomiser is an exception: install UA first, then IR.
+- Item Randomiser and SCS are exceptions: install UA first, then IR or SCS. When using all three, install UA first, then IR, and then SCS.
 - When both Weimer's Item Upgrade and Daulmanakan's More work for Cromwell are installed, and "Allow non-unique RoP+2" is not, Cromwell won't offer to create Ring of Perseverance +1 (+2 is still fine).
 
 ## Which items are affected?

--- a/ua/ua.ini
+++ b/ua/ua.ini
@@ -6,4 +6,4 @@ Readme = https://github.com/BGforgeNet/bg2-uniqueartifacts/blob/master/README.md
 Forum = https://forums.bgforge.net/viewforum.php?f=30
 Homepage = https://bgforge.net/unique-artifacts/
 Download = https://github.com/BGforgeNet/bg2-uniqueartifacts
-BEFORE = randomiser
+BEFORE = randomiser, stratagems


### PR DESCRIPTION
SCS relies (e.g. by adding proficiency points) on items that creatures
possess at the moment of its installation. Because of that, installing
UA after SCS may lead to a situation where a specific creature has
proficiency points in a weapon that they no longer even have.

For this reason, SCS should be treated like Item Randomiser, and the
recommended order of installation should be UA first, and SCS last.
Also, since SCS itself needs to be installed after IR, the order when
using all the three mods should be UA, then IR, and then SCS.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>