### PR TITLE
Add a new component to reduce the number of wands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Unique Artifacts is a mod for BG1/BG2, designed to reduce the number of magical 
   - [Allow non-unique Amulet of Protection +1](#allow-non-unique-amulet-of-protection-1)
   - [Allow non-unique Ring of Protection +2 and Cloak of Protection +2](#allow-non-unique-ring-of-protection-2-and-cloak-of-protection-2)
   - [Allow non-unique Boots of Speed](#allow-non-unique-boots-of-speed)
+  - [Reduce the number of wands](#reduce-the-number-of-wands)
   - [Core](#core)
     - [Strict](#strict)
     - [Expanded](#expanded)
@@ -60,6 +61,9 @@ Excludes RoP +2 and CoP +2 from core overhaul and fixes their descriptions so th
 
 ### Allow non-unique Boots of Speed
 Excludes Boots of Speed from core overhaul and fixes their description so that it no longer implies uniqueness.
+
+### Reduce the number of wands
+Limits how many wands of each type can drop as loot, and also removes most wands from shops. Disallows selling wands, effectively blocking the somewhat questionable recharging mechanism.
 
 ### Core
 

--- a/ua/compatibility/ua.tpa
+++ b/ua/compatibility/ua.tpa
@@ -36,3 +36,10 @@ ACTION_IF NOT MOD_IS_INSTALLED ~ua.tp2~ (ID_OF_LABEL ~ua.tp2~ ~g_ua_allow_speed~
     OUTER_SET $item_source_compat(~boot01~ ~tokcre01.dlg~) = 1 // Token machine in Spellhold
   END
 END
+
+// reduce wands
+OUTER_SET reduce_wands = 0
+ACTION_IF MOD_IS_INSTALLED ~ua.tp2~ (ID_OF_LABEL ~ua.tp2~ ~g_ua_reduce_wands~) BEGIN
+  PRINT @36
+  OUTER_SET reduce_wands = 1
+END

--- a/ua/core/items.tpa
+++ b/ua/core/items.tpa
@@ -25,6 +25,11 @@ DEFINE_ACTION_MACRO read_item_sources BEGIN
       LPM read_item_sources_2da
     BUT_ONLY
   END
+  ACTION_IF reduce_wands == 1 BEGIN
+    COPY - ~%MOD_FOLDER%/items/wands_%game%.bsv~ ~%MOD_FOLDER%-inlined/wands_%game%.bsv~
+      LPM read_item_sources_2da
+    BUT_ONLY
+  END
 END
 
 ACTION_IF GAME_INCLUDES ~bg1~ BEGIN

--- a/ua/items/wands_bg1.bsv
+++ b/ua/items/wands_bg1.bsv
@@ -1,0 +1,57 @@
+wand02  ar1803.are  | Wand of Fear             | Cloakwood Mines, locked chest in Davaeorn's lair, 15 charges
+wand02  beyn.cre    | Wand of Fear             | Beyn, fighter/mage on Ice Island, 13 charges
+wand02  bpxith01.sto| Wand of Fear             | Xithiss, mind flayer merchant in Black Pits
+wand02  bpxith02.sto| Wand of Fear             | Xithiss, mind flayer merchant in Black Pits
+wand02  bpxith03.sto| Wand of Fear             | Xithiss, mind flayer merchant in Black Pits
+wand02  highhedg.sto| Wand of Fear             | Thalantyr, mage shop in High Hedge, 20 charges
+                    |                          | 
+wand03  ar0603.are  | Wand of Magic Missiles   | Seven Suns, basement, 30 charges
+wand03  ar1501.are  | Wand of Magic Missiles   | Balduran's ship, ground floor, 5 charges
+wand03  bpxith01.sto| Wand of Magic Missiles   | Xithiss, mind flayer merchant in Black Pits
+wand03  bpxith02.sto| Wand of Magic Missiles   | Xithiss, mind flayer merchant in Black Pits
+wand03  bpxith03.sto| Wand of Magic Missiles   | Xithiss, mind flayer merchant in Black Pits
+wand03  tranzi.cre  | Wand of Magic Missiles   | Tranzig, 2nd floor in Feldepost Inn, 31 charges
+                    |                          | 
+wand04  ar3601.are  | Wand of Paralyzation     | Black Alaric's cave, 13 charges
+wand04  bpxith02.sto| Wand of Paralyzation     | Xithiss, mind flayer merchant in Black Pits
+wand04  bpxith03.sto| Wand of Paralyzation     | Xithiss, mind flayer merchant in Black Pits
+wand04  cuchol.cre  | Wand of Paralyzation     | Cuchol, fighter/mage on Ice Island, 11 charges
+wand04  resar.cre   | Wand of Paralyzation     | Resar, Halruaan mage in Thieves' Guild, 12 charges
+                    |                          | 
+wand05  ar0514.are  | Wand of Fire             | Durlag's Tower, 5th subterranean level, 12 charges
+wand05  ar2615.are  | Wand of Fire             | Candlekeep Catacombs, 1st level, 16 charges
+wand05  ar3901.are  | Wand of Fire             | Ulcaster School, dungeon, 8 charges
+wand05  bpxith01.sto| Wand of Fire             | Xithiss, mind flayer merchant in Black Pits
+wand05  bpxith02.sto| Wand of Fire             | Xithiss, mind flayer merchant in Black Pits
+wand05  bpxith03.sto| Wand of Fire             | Xithiss, mind flayer merchant in Black Pits
+                    |                          | 
+wand06  ar2101.are  | Wand of Frost            | Cloakwood, Spider Nest, 12 charges
+wand06  ar5400.are  | Wand of Frost            | Nashkel Mines, tree, 10 charges
+wand06  bpaluena.cre| Wand of Frost            | Thespia, ? in Black Pits
+wand06  bpxith01.sto| Wand of Frost            | Xithiss, mind flayer merchant in Black Pits
+wand06  bpxith02.sto| Wand of Frost            | Xithiss, mind flayer merchant in Black Pits
+wand06  bpxith03.sto| Wand of Frost            | Xithiss, mind flayer merchant in Black Pits
+wand06  centeo.cre  | Wand of Frost            | Centeol, Spider Nest in Cloakwood, undroppable
+wand06  ulgoth.sto  | Wand of Frost            | Ulgoth's Beard, store, 29 charges
+                    |                          | 
+wand07  alai.cre    | Wand of Lightning        | Alai, party at the top of the Iron Throne, 10 charges
+wand07  ar0504.are  | Wand of Lightning        | Durlag's Tower, third floor, 16 charges
+wand07  ar3321.are  | Wand of Lightning        | Beregost, 2nd floor in Travenhurst Manor, 6 charges
+wand07  bpxith01.sto| Wand of Lightning        | Xithiss, mind flayer merchant in Black Pits
+wand07  bpxith02.sto| Wand of Lightning        | Xithiss, mind flayer merchant in Black Pits
+wand07  bpxith03.sto| Wand of Lightning        | Xithiss, mind flayer merchant in Black Pits
+                    |                          | 
+wand08  cult2.cre   | Wand of Sleep            | Cult Wizard, Ulgoth's Beard, 4 charges
+wand08  highhedg.sto| Wand of Sleep            | Thalantyr, mage shop in High Hedge, 20 charges
+wand08  sto0703.sto | Wand of Sleep            | Halbazzer Drin, mage shop in Sorcerous Sundries, 20 charges
+                    |                          | 
+wand10  ar0511.are  | Wand of Monster Summoning| Durlag's Tower, second subterranean level, 5 charges
+wand10  ar5001.are  | Wand of Monster Summoning| Valley of the Tombs, tomb, 8 charges
+wand10  bpxith02.sto| Wand of Monster Summoning| Xithiss, mind flayer merchant in Black Pits
+wand10  bpxith03.sto| Wand of Monster Summoning| Xithiss, mind flayer merchant in Black Pits
+wand10  sto0703.sto | Wand of Monster Summoning| Halbazzer Drin, mage shop in Sorcerous Sundries, 20 charges
+                    |                          | 
+wand11  aasim.cre   | Wand of the Heavens      | Aasim, party at the top of the Iron Throne, 11 charges
+wand11  bpxith03.sto| Wand of the Heavens      | Xithiss, mind flayer merchant in Black Pits
+wand11  sto0703.sto | Wand of the Heavens      | Halbazzer Drin, mage shop in Sorcerous Sundries, 20 charges
+wand11  ulgoth.sto  | Wand of the Heavens      | Ulgoth's Beard, store, 25 charges

--- a/ua/tra/english/setup.tra
+++ b/ua/tra/english/setup.tra
@@ -32,6 +32,8 @@
 @32 = ~This component must be installed before Core~
 @33 = ~BG2EE~
 @34 = ~Rogue Rebalancing: Shadow Thief improvements~
+@35 = ~Reduce the number of wands~
+@36 = ~Reduced number of wands~
 
 @100 = ~Remove bonus merchants~
 @101 = ~Less magical items~

--- a/ua/ua.tp2
+++ b/ua/ua.tp2
@@ -42,6 +42,14 @@ REQUIRE_PREDICATE NOT
   ) @32
 INCLUDE ~%MOD_FOLDER%/non-unique/boots.tpa~
 
+BEGIN @35 //Wands
+LABEL ~g_ua_reduce_wands~
+REQUIRE_PREDICATE GAME_INCLUDES ~bg1~ OR GAME_INCLUDES ~bg2~ @30
+REQUIRE_PREDICATE NOT
+  ( MOD_IS_INSTALLED ~ua.tp2~ (ID_OF_LABEL ~ua.tp2~ ~g_ua_core_strict~)
+    OR MOD_IS_INSTALLED ~ua.tp2~ (ID_OF_LABEL ~ua.tp2~ ~g_ua_core_expanded~)
+  ) @32
+
 BEGIN @6 //Expanded
 LABEL ~g_ua_core_expanded~
 REQUIRE_PREDICATE GAME_INCLUDES ~bg1~ OR GAME_INCLUDES ~bg2~ @30


### PR DESCRIPTION
Add a new component called "Reduce the number of wands". This component
limits the number of wands that drop and are sold in shops. Additionaly,
it also disables the somewhat questionable recharging mechanism, i.e.
being able to sell and re-buy the same wand with the maximum amount of
charges.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>